### PR TITLE
Prevent empty upload

### DIFF
--- a/source/jquery.singleuploadimage.js
+++ b/source/jquery.singleuploadimage.js
@@ -32,32 +32,33 @@
         }, options);
 
         $('#' + settings.inputId).bind('change', function() {
-            $this.css('backgroundImage', 'none');
-            var fd = new FormData();
-            fd.append($('#' + settings.inputId).attr('name'), $('#' + settings.inputId).get(0).files[0]);
-
-            var xhr = new XMLHttpRequest();
-            xhr.addEventListener("load", function(ev) {
-                $this.html('');
-                var res = eval("(" + ev.target.responseText + ")");
-
-                if(res.code != 0) {
-                    settings.onError(res.code);
-                    return;
-                }
-                var review = ('<img src="'+res.url+'" style="width:'+$this.width()+'px;height:'+$this.height()+'px;"/>');
-                $this.append(review);
-                settings.onSuccess(res.url, res.data);
-
-            },
-            false);
-            xhr.upload.addEventListener("progress", function(ev) {
-                settings.OnProgress(ev.loaded, ev.total);
-            }, false);
-            
-            xhr.open("POST", settings.action, true);
-            xhr.send(fd);  
-
+            if($('#' + settings.inputId).get(0).files[0] !== undefined) {
+                $this.css('backgroundImage', 'none');
+                var fd = new FormData();
+                fd.append($('#' + settings.inputId).attr('name'), $('#' + settings.inputId).get(0).files[0]);
+    
+                var xhr = new XMLHttpRequest();
+                xhr.addEventListener("load", function(ev) {
+                    $this.html('');
+                    var res = eval("(" + ev.target.responseText + ")");
+    
+                    if(res.code != 0) {
+                        settings.onError(res.code);
+                        return;
+                    }
+                    var review = ('<img src="'+res.url+'" style="width:'+$this.width()+'px;height:'+$this.height()+'px;"/>');
+                    $this.append(review);
+                    settings.onSuccess(res.url, res.data);
+    
+                },
+                false);
+                xhr.upload.addEventListener("progress", function(ev) {
+                    settings.OnProgress(ev.loaded, ev.total);
+                }, false);
+                
+                xhr.open("POST", settings.action, true);
+                xhr.send(fd);
+            }
         });  
        
     	return this;


### PR DESCRIPTION
The added if($('#' + settings.inputId).get(0).files[0] !== undefined) { } statement prevents an error and empty div to appear when the user clicks the 'cancel' button in the upload dialog box of their browser.